### PR TITLE
ci: do not group k8s deps in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -34,8 +34,10 @@
       "matchDatasources": [
         "go"
       ],
-      "matchPackagePatterns": [
-        "*"
+      "matchPackageNames": [
+        // Avoid k8s dependencies from being grouped with other dependencies. We want to be careful
+        // with how we update them, since we may get indirect upgrades in cloudnative-pg.
+        "!/k8s.io/"
       ],
       "matchUpdateTypes": [
         "minor",


### PR DESCRIPTION
Avoid *k8s.io dependencies from being grouped all together in renovate, since we want to prevent unwanted dependencies from being fed to cnpg.