### PR TITLE
fix: notify in the logs about backup completion

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -218,5 +218,7 @@ func (b *Command) Take(
 		return err
 	}
 
+	log.Info("Completed barman-cloud-backup", "options", options)
+
 	return nil
 }


### PR DESCRIPTION
Log the completion of the backup in addition to the start of it