### PR TITLE
feat: use endpointURL for STORAGE_EMULATOR_HOST env var on GCS

### DIFF
--- a/pkg/credentials/env.go
+++ b/pkg/credentials/env.go
@@ -105,6 +105,9 @@ func envSetCloudCredentials(
 	}
 
 	if configuration.BarmanCredentials.Google != nil {
+		if configuration.EndpointURL != "" {
+			env = append(env, fmt.Sprintf("STORAGE_EMULATOR_HOST=%s", configuration.EndpointURL))
+		}
 		return envSetGoogleCredentials(ctx, c, namespace, configuration.BarmanCredentials.Google, env)
 	}
 


### PR DESCRIPTION
If googleCredentials are in use and endpointURL is defined, the STORAGE_EMULATOR_HOST environment variable is set to the endpointURL value. This forces anonymous authentication.