### PR TITLE
fix(PITR): compare TargetLSN with backup EndLSN instead of BeginLSN

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -183,7 +183,7 @@ func (catalog *Catalog) findClosestBackupFromTargetLSN(
 		if (strconv.Itoa(barmanBackup.TimeLine) == targetTLI ||
 			// if targetTLI is not an integer, it will be ignored actually
 			currentTLIRegex.MatchString(targetTLI)) &&
-			types.LSN(barmanBackup.BeginLSN).Less(targetLSN) {
+			types.LSN(barmanBackup.EndLSN).Less(targetLSN) {
 			return &catalog.List[i], nil
 		}
 	}


### PR DESCRIPTION
Closes cloudnative-pg/cloudnative-pg#6536