### PR TITLE
feat: allow barman cli to use azure default credentials

### DIFF
--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -110,23 +110,6 @@ func appendCloudProviderOptions(
 			options,
 			"--cloud-provider",
 			"azure-blob-storage")
-
-		if !credentials.Azure.InheritFromAzureAD {
-			break
-		}
-
-		if !capabilities.HasAzureManagedIdentity {
-			err := fmt.Errorf(
-				"barman >= 2.18 is required to use azureInheritFromAzureAD, current: %v",
-				capabilities.Version)
-			logger.Error(err, "Barman version not supported")
-			return nil, err
-		}
-
-		options = append(
-			options,
-			"--credential",
-			"managed-identity")
 	case credentials.Google != nil:
 		if !capabilities.HasGoogle {
 			err := fmt.Errorf(


### PR DESCRIPTION
chore: allow barman cli to use azure default credentials when `inheritFromAzureAD` is set to true, currently when this field is set, one flag `--credentials managed-identity` is appended, which will mandate barman cloud cli to use managed identity instead of trying to use all kinds of default credentials

for https://github.com/cloudnative-pg/barman-cloud/issues/59

tests:
- [x] inject pod with storage account env
- [x] inject pod with service principal env