### PR TITLE
feat: support DefaultAzureCredential for Azure Blob Storage authentication

### DIFF
--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -115,6 +115,10 @@ func appendCloudProviderOptions(
 			break
 		}
 
+		if checkUseDefaultAzureCredentials(ctx) {
+			break
+		}
+
 		if !capabilities.HasAzureManagedIdentity {
 			err := fmt.Errorf(
 				"barman >= 2.18 is required to use azureInheritFromAzureAD, current: %v",
@@ -142,4 +146,20 @@ func appendCloudProviderOptions(
 	}
 
 	return options, nil
+}
+
+type contextKey string
+
+const useDefaultAzureCredentials contextKey = "useDefaultAzureCredentials"
+
+func checkUseDefaultAzureCredentials(ctx context.Context) bool {
+	v := ctx.Value(useDefaultAzureCredentials)
+	if v == nil {
+		return false
+	}
+	result, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return result
 }

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -111,11 +111,11 @@ func appendCloudProviderOptions(
 			"--cloud-provider",
 			"azure-blob-storage")
 
-		if !credentials.Azure.InheritFromAzureAD {
+		if useDefaultAzureCredentials(ctx) {
 			break
 		}
 
-		if CheckUseDefaultAzureCredentials(ctx) {
+		if !credentials.Azure.InheritFromAzureAD {
 			break
 		}
 
@@ -150,12 +150,10 @@ func appendCloudProviderOptions(
 
 type contextKey string
 
-// useDefaultAzureCredentials context key holding the flag if to use DefaultAzureCredentials
-// for azure-blob-storage
-const useDefaultAzureCredentials contextKey = "useDefaultAzureCredentials"
+// contextKeyUseDefaultAzureCredentials contains a bool indicating if the default azure credentials should be used
+const contextKeyUseDefaultAzureCredentials contextKey = "useDefaultAzureCredentials"
 
-// CheckUseDefaultAzureCredentials return true if useDefaultAzureCredentials is set
-func CheckUseDefaultAzureCredentials(ctx context.Context) bool {
+func useDefaultAzureCredentials(ctx context.Context) bool {
 	v := ctx.Value(useDefaultAzureCredentials)
 	if v == nil {
 		return false
@@ -167,7 +165,8 @@ func CheckUseDefaultAzureCredentials(ctx context.Context) bool {
 	return result
 }
 
-// NewContextWithUseDefaultAzureCredentials create a context with useDefaultAzureCredentials set
-func NewContextWithUseDefaultAzureCredentials(ctx context.Context) context.Context {
-	return context.WithValue(ctx, useDefaultAzureCredentials, true)
+// ContextWithDefaultAzureCredentials create a context that contains the contextKeyUseDefaultAzureCredentials flag.
+// When set to true barman-cloud will use the default Azure credentials.
+func ContextWithDefaultAzureCredentials(ctx context.Context, enabled bool) context.Context {
+	return context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, enabled)
 }

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -115,7 +115,7 @@ func appendCloudProviderOptions(
 			break
 		}
 
-		if checkUseDefaultAzureCredentials(ctx) {
+		if CheckUseDefaultAzureCredentials(ctx) {
 			break
 		}
 
@@ -150,9 +150,12 @@ func appendCloudProviderOptions(
 
 type contextKey string
 
+// useDefaultAzureCredentials context key holding the flag if to use DefaultAzureCredentials
+// for azure-blob-storage
 const useDefaultAzureCredentials contextKey = "useDefaultAzureCredentials"
 
-func checkUseDefaultAzureCredentials(ctx context.Context) bool {
+// CheckUseDefaultAzureCredentials return true if useDefaultAzureCredentials is set
+func CheckUseDefaultAzureCredentials(ctx context.Context) bool {
 	v := ctx.Value(useDefaultAzureCredentials)
 	if v == nil {
 		return false
@@ -162,4 +165,9 @@ func checkUseDefaultAzureCredentials(ctx context.Context) bool {
 		return false
 	}
 	return result
+}
+
+// NewContextWithUseDefaultAzureCredentials create a context with useDefaultAzureCredentials set
+func NewContextWithUseDefaultAzureCredentials(ctx context.Context) context.Context {
+	return context.WithValue(ctx, useDefaultAzureCredentials, true)
 }

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -154,7 +154,7 @@ type contextKey string
 const contextKeyUseDefaultAzureCredentials contextKey = "useDefaultAzureCredentials"
 
 func useDefaultAzureCredentials(ctx context.Context) bool {
-	v := ctx.Value(useDefaultAzureCredentials)
+	v := ctx.Value(contextKeyUseDefaultAzureCredentials)
 	if v == nil {
 		return false
 	}

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -65,17 +65,17 @@ var _ = Describe("useDefaultAzureCredentials", func() {
 	})
 
 	It("should be false if ctx contains an invalid value", func(ctx SpecContext) {
-		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, "invalidValue")
+		newCtx := context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, "invalidValue")
 		Expect(useDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
 	It("should be false if ctx contains false value", func(ctx SpecContext) {
-		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, false)
+		newCtx := context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, false)
 		Expect(useDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
 	It("should be true only if ctx contains true value", func(ctx SpecContext) {
-		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, true)
+		newCtx := context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, true)
 		Expect(useDefaultAzureCredentials(newCtx)).To(BeTrue())
 	})
 })

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	"context"
 	"strings"
 
 	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
@@ -55,5 +56,26 @@ var _ = Describe("barmanCloudWalRestoreOptions", func() {
 				Equal(
 					"s3://bucket-name/ test-cluster --read-timeout=60 -vv",
 				))
+	})
+})
+
+var _ = Describe("checkUseDefaultAzureCredentials", func() {
+	It("checkUseDefaultAzureCredentials should be false by default", func(ctx SpecContext) {
+		Expect(checkUseDefaultAzureCredentials(ctx)).To(BeFalse())
+	})
+
+	It("checkUseDefaultAzureCredentials should be false if ctx contains invalid value", func(ctx SpecContext) {
+		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, "invalidValue")
+		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+	})
+
+	It("checkUseDefaultAzureCredentials should be false if ctx contains false value", func(ctx SpecContext) {
+		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, false)
+		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+	})
+
+	It("checkUseDefaultAzureCredentials should be true only if ctx contains true value", func(ctx SpecContext) {
+		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, true)
+		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeTrue())
 	})
 })

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -61,21 +61,21 @@ var _ = Describe("barmanCloudWalRestoreOptions", func() {
 
 var _ = Describe("checkUseDefaultAzureCredentials", func() {
 	It("checkUseDefaultAzureCredentials should be false by default", func(ctx SpecContext) {
-		Expect(checkUseDefaultAzureCredentials(ctx)).To(BeFalse())
+		Expect(CheckUseDefaultAzureCredentials(ctx)).To(BeFalse())
 	})
 
 	It("checkUseDefaultAzureCredentials should be false if ctx contains invalid value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, "invalidValue")
-		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
 	It("checkUseDefaultAzureCredentials should be false if ctx contains false value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, false)
-		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
 	It("checkUseDefaultAzureCredentials should be true only if ctx contains true value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, true)
-		Expect(checkUseDefaultAzureCredentials(newCtx)).To(BeTrue())
+		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeTrue())
 	})
 })

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -59,23 +59,23 @@ var _ = Describe("barmanCloudWalRestoreOptions", func() {
 	})
 })
 
-var _ = Describe("checkUseDefaultAzureCredentials", func() {
-	It("checkUseDefaultAzureCredentials should be false by default", func(ctx SpecContext) {
-		Expect(CheckUseDefaultAzureCredentials(ctx)).To(BeFalse())
+var _ = Describe("useDefaultAzureCredentials", func() {
+	It("should be false by default", func(ctx SpecContext) {
+		Expect(useDefaultAzureCredentials(ctx)).To(BeFalse())
 	})
 
-	It("checkUseDefaultAzureCredentials should be false if ctx contains invalid value", func(ctx SpecContext) {
+	It("should be false if ctx contains an invalid value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, "invalidValue")
-		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+		Expect(useDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
-	It("checkUseDefaultAzureCredentials should be false if ctx contains false value", func(ctx SpecContext) {
+	It("should be false if ctx contains false value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, false)
-		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeFalse())
+		Expect(useDefaultAzureCredentials(newCtx)).To(BeFalse())
 	})
 
-	It("checkUseDefaultAzureCredentials should be true only if ctx contains true value", func(ctx SpecContext) {
+	It("should be true only if ctx contains true value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, useDefaultAzureCredentials, true)
-		Expect(CheckUseDefaultAzureCredentials(newCtx)).To(BeTrue())
+		Expect(useDefaultAzureCredentials(newCtx)).To(BeTrue())
 	})
 })


### PR DESCRIPTION
This patch introduces support for Azure AD authentication using the DefaultAzureCredential mechanism.

Closes #59 