### PR TITLE
feat: add lz4, xz, and zstd compression

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -57,6 +57,15 @@ const (
 
 	// CompressionTypeSnappy means snappy compression is performed
 	CompressionTypeSnappy = CompressionType("snappy")
+
+	// CompressionTypeXZ means xz compression is performed
+	CompressionTypeXZ = CompressionType("xz")
+
+	// CompressionTypeLZ4 means lz4 compression is performed
+	CompressionTypeLZ4 = CompressionType("lz4")
+
+	// CompressionTypeZSTD means zstd compression is performed
+	CompressionTypeZSTD = CompressionType("zstd")
 )
 
 // BarmanCredentials an object containing the potential credentials for each cloud provider
@@ -205,7 +214,7 @@ type BarmanObjectStoreConfiguration struct {
 type WalBackupConfiguration struct {
 	// Compress a WAL file before sending it to the object store. Available
 	// options are empty string (no compression, default), `gzip`, `bzip2` or `snappy`.
-	// +kubebuilder:validation:Enum=gzip;bzip2;snappy
+	// +kubebuilder:validation:Enum=gzip;bzip2;snappy;xz;lz4;zstd
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 
@@ -265,7 +274,7 @@ type DataBackupConfiguration struct {
 	// Compress a backup file (a tar file per tablespace) while streaming it
 	// to the object store. Available options are empty string (no
 	// compression, default), `gzip`, `bzip2` or `snappy`.
-	// +kubebuilder:validation:Enum=gzip;bzip2;snappy
+	// +kubebuilder:validation:Enum=gzip;bzip2;snappy;xz;lz4;zstd
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -55,17 +55,17 @@ const (
 	// CompressionTypeBzip2 means bzip2 compression is performed
 	CompressionTypeBzip2 = CompressionType("bzip2")
 
+	// CompressionTypeLz4 means lz4 compression is performed
+	CompressionTypeLz4 = CompressionType("lz4")
+
 	// CompressionTypeSnappy means snappy compression is performed
 	CompressionTypeSnappy = CompressionType("snappy")
 
-	// CompressionTypeXZ means xz compression is performed
-	CompressionTypeXZ = CompressionType("xz")
+	// CompressionTypeXz means xz compression is performed
+	CompressionTypeXz = CompressionType("xz")
 
-	// CompressionTypeLZ4 means lz4 compression is performed
-	CompressionTypeLZ4 = CompressionType("lz4")
-
-	// CompressionTypeZSTD means zstd compression is performed
-	CompressionTypeZSTD = CompressionType("zstd")
+	// CompressionTypeZstd means zstd compression is performed
+	CompressionTypeZstd = CompressionType("zstd")
 )
 
 // BarmanCredentials an object containing the potential credentials for each cloud provider
@@ -213,8 +213,9 @@ type BarmanObjectStoreConfiguration struct {
 // WAL stream
 type WalBackupConfiguration struct {
 	// Compress a WAL file before sending it to the object store. Available
-	// options are empty string (no compression, default), `gzip`, `bzip2` or `snappy`.
-	// +kubebuilder:validation:Enum=gzip;bzip2;snappy;xz;lz4;zstd
+	// options are empty string (no compression, default), `gzip`, `bzip2`,
+	// `lz4`, `snappy`, `xz`, and `zstd`.
+	// +kubebuilder:validation:Enum=bzip2;gzip;lz4;snappy;xz;zstd
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 
@@ -273,8 +274,8 @@ type WalBackupConfiguration struct {
 type DataBackupConfiguration struct {
 	// Compress a backup file (a tar file per tablespace) while streaming it
 	// to the object store. Available options are empty string (no
-	// compression, default), `gzip`, `bzip2` or `snappy`.
-	// +kubebuilder:validation:Enum=gzip;bzip2;snappy;xz;lz4;zstd
+	// compression, default), `gzip`, `bzip2`, `lz4`, `snappy`, `xz`, and `zstd`.
+	// +kubebuilder:validation:Enum=bzip2;gzip;lz4;snappy;xz;zstd
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 

--- a/pkg/archiver/command.go
+++ b/pkg/archiver/command.go
@@ -124,18 +124,8 @@ func (archiver *WALArchiver) BarmanCloudWalArchiveOptions(
 	}
 
 	var options []string
-	compressionSupported := map[barmanApi.CompressionType]bool{
-		barmanApi.CompressionTypeNone:   true,
-		barmanApi.CompressionTypeBzip2:  true,
-		barmanApi.CompressionTypeGzip:   true,
-		barmanApi.CompressionTypeSnappy: capabilities.HasSnappy,
-		barmanApi.CompressionTypeXZ:     capabilities.HasXZ,
-		barmanApi.CompressionTypeLZ4:    capabilities.HasLZ4,
-		barmanApi.CompressionTypeZSTD:   capabilities.HasZSTD,
-	}
-
 	if configuration.Wal != nil {
-		if !compressionSupported[configuration.Wal.Compression] {
+		if !capabilities.HasCompression(configuration.Wal.Compression) {
 			return nil, fmt.Errorf("%v compression is not supported in Barman %v",
 				configuration.Wal.Compression, capabilities.Version)
 		}

--- a/pkg/archiver/command.go
+++ b/pkg/archiver/command.go
@@ -124,9 +124,20 @@ func (archiver *WALArchiver) BarmanCloudWalArchiveOptions(
 	}
 
 	var options []string
+	compressionSupported := map[barmanApi.CompressionType]bool{
+		barmanApi.CompressionTypeNone:   true,
+		barmanApi.CompressionTypeBzip2:  true,
+		barmanApi.CompressionTypeGzip:   true,
+		barmanApi.CompressionTypeSnappy: capabilities.HasSnappy,
+		barmanApi.CompressionTypeXZ:     capabilities.HasXZ,
+		barmanApi.CompressionTypeLZ4:    capabilities.HasLZ4,
+		barmanApi.CompressionTypeZSTD:   capabilities.HasZSTD,
+	}
+
 	if configuration.Wal != nil {
-		if configuration.Wal.Compression == barmanApi.CompressionTypeSnappy && !capabilities.HasSnappy {
-			return nil, fmt.Errorf("snappy compression is not supported in Barman %v", capabilities.Version)
+		if !compressionSupported[configuration.Wal.Compression] {
+			return nil, fmt.Errorf("%v compression is not supported in Barman %v",
+				configuration.Wal.Compression, capabilities.Version)
 		}
 		if len(configuration.Wal.Compression) != 0 {
 			options = append(

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -59,16 +59,7 @@ func (b *Command) GetDataConfiguration(
 		return options, nil
 	}
 
-	compressionSupported := map[barmanApi.CompressionType]bool{
-		barmanApi.CompressionTypeNone:   true,
-		barmanApi.CompressionTypeBzip2:  true,
-		barmanApi.CompressionTypeGzip:   true,
-		barmanApi.CompressionTypeSnappy: b.capabilities.HasSnappy,
-		barmanApi.CompressionTypeXZ:     b.capabilities.HasXZ,
-		barmanApi.CompressionTypeLZ4:    b.capabilities.HasLZ4,
-		barmanApi.CompressionTypeZSTD:   b.capabilities.HasZSTD,
-	}
-	if !compressionSupported[b.configuration.Data.Compression] {
+	if !b.capabilities.HasCompression(b.configuration.Data.Compression) {
 		return nil, fmt.Errorf("%v compression is not supported in Barman %v",
 			b.configuration.Data.Compression, b.capabilities.Version)
 	}

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -59,8 +59,18 @@ func (b *Command) GetDataConfiguration(
 		return options, nil
 	}
 
-	if b.configuration.Data.Compression == barmanApi.CompressionTypeSnappy && !b.capabilities.HasSnappy {
-		return nil, fmt.Errorf("snappy compression is not supported in Barman %v", b.capabilities.Version)
+	compressionSupported := map[barmanApi.CompressionType]bool{
+		barmanApi.CompressionTypeNone:   true,
+		barmanApi.CompressionTypeBzip2:  true,
+		barmanApi.CompressionTypeGzip:   true,
+		barmanApi.CompressionTypeSnappy: b.capabilities.HasSnappy,
+		barmanApi.CompressionTypeXZ:     b.capabilities.HasXZ,
+		barmanApi.CompressionTypeLZ4:    b.capabilities.HasLZ4,
+		barmanApi.CompressionTypeZSTD:   b.capabilities.HasZSTD,
+	}
+	if !compressionSupported[b.configuration.Data.Compression] {
+		return nil, fmt.Errorf("%v compression is not supported in Barman %v",
+			b.configuration.Data.Compression, b.capabilities.Version)
 	}
 
 	if len(b.configuration.Data.Compression) != 0 {

--- a/pkg/capabilities/detect.go
+++ b/pkg/capabilities/detect.go
@@ -42,6 +42,12 @@ func detect(version *semver.Version) *Capabilities {
 	newCapabilities.Version = version
 
 	switch {
+	case version.GE(semver.Version{Major: 3, Minor: 12}):
+		// lz4, xz, and zstd compression support, added in barman 3.12
+		newCapabilities.HasLZ4 = true
+		newCapabilities.HasXZ = true
+		newCapabilities.HasZSTD = true
+		fallthrough
 	case version.GE(semver.Version{Major: 3, Minor: 4}):
 		// The --name flag was added to Barman in version 3.3 but we also require the
 		// barman-cloud-backup-show command which was not added until Barman version 3.4

--- a/pkg/capabilities/detect.go
+++ b/pkg/capabilities/detect.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 )
 
 // capabilities stores the current Barman capabilities
@@ -34,6 +36,12 @@ var capabilities *Capabilities
 func detect(version *semver.Version) *Capabilities {
 	contextLogger := log.FromContext(context.Background())
 	newCapabilities := new(Capabilities)
+	newCapabilities.supportedCompressions = []barmanApi.CompressionType{
+		barmanApi.CompressionTypeNone,
+		barmanApi.CompressionTypeBzip2,
+		barmanApi.CompressionTypeGzip,
+	}
+
 	if version == nil {
 		contextLogger.Info("Missing Barman Cloud installation in the operand image")
 		return newCapabilities
@@ -44,9 +52,12 @@ func detect(version *semver.Version) *Capabilities {
 	switch {
 	case version.GE(semver.Version{Major: 3, Minor: 12}):
 		// lz4, xz, and zstd compression support, added in barman 3.12
-		newCapabilities.HasLZ4 = true
-		newCapabilities.HasXZ = true
-		newCapabilities.HasZSTD = true
+		newCapabilities.supportedCompressions = append(
+			newCapabilities.supportedCompressions,
+			barmanApi.CompressionTypeLz4,
+			barmanApi.CompressionTypeXz,
+			barmanApi.CompressionTypeZstd,
+		)
 		fallthrough
 	case version.GE(semver.Version{Major: 3, Minor: 4}):
 		// The --name flag was added to Barman in version 3.3 but we also require the
@@ -63,7 +74,10 @@ func detect(version *semver.Version) *Capabilities {
 		// Barman-cloud-check-wal-archive, added in Barman >= 2.18
 		newCapabilities.HasCheckWalArchive = true
 		// Snappy compression support, added in Barman >= 2.18
-		newCapabilities.HasSnappy = true
+		newCapabilities.supportedCompressions = append(
+			newCapabilities.supportedCompressions,
+			barmanApi.CompressionTypeSnappy,
+		)
 		// error codes for wal-restore command added in Barman >= 2.18
 		newCapabilities.HasErrorCodesForWALRestore = true
 		// azure-identity credential of type managed-identity added in Barman >= 2.18

--- a/pkg/capabilities/detect_test.go
+++ b/pkg/capabilities/detect_test.go
@@ -19,12 +19,14 @@ package capabilities
 import (
 	"github.com/blang/semver"
 
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("detect capabilities", func() {
-	It("ensures that all capabilities are true for the 3.4 version", func() {
+	It("ensures that all capabilities are true for the 3.12 version", func() {
 		version, err := semver.ParseTolerant("3.12.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)
@@ -37,17 +39,22 @@ var _ = Describe("detect capabilities", func() {
 			HasRetentionPolicy:         true,
 			HasTags:                    true,
 			HasCheckWalArchive:         true,
-			HasSnappy:                  true,
-			HasZSTD:                    true,
-			HasLZ4:                     true,
-			HasXZ:                      true,
 			HasErrorCodesForWALRestore: true,
 			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+				barmanApi.CompressionTypeLz4,
+				barmanApi.CompressionTypeXz,
+				barmanApi.CompressionTypeZstd,
+				barmanApi.CompressionTypeSnappy,
+			},
 		}))
 	})
 
-	It("ensures that all capabilities are true for the 3.4 version", func() {
+	It("ensures that barman versions 3.4 have no additional compression capabilities", func() {
 		version, err := semver.ParseTolerant("3.4.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)
@@ -60,10 +67,15 @@ var _ = Describe("detect capabilities", func() {
 			HasRetentionPolicy:         true,
 			HasTags:                    true,
 			HasCheckWalArchive:         true,
-			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
 			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+				barmanApi.CompressionTypeSnappy,
+			},
 		}))
 	})
 
@@ -79,10 +91,15 @@ var _ = Describe("detect capabilities", func() {
 			HasRetentionPolicy:         true,
 			HasTags:                    true,
 			HasCheckWalArchive:         true,
-			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
 			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+				barmanApi.CompressionTypeSnappy,
+			},
 		}))
 	})
 
@@ -97,14 +114,19 @@ var _ = Describe("detect capabilities", func() {
 			HasRetentionPolicy:         true,
 			HasTags:                    true,
 			HasCheckWalArchive:         true,
-			HasSnappy:                  true,
 			HasErrorCodesForWALRestore: true,
 			HasErrorCodesForRestore:    true,
 			HasAzureManagedIdentity:    true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+				barmanApi.CompressionTypeSnappy,
+			},
 		}))
 	})
 
-	It("ensures that barmans versions below 2.18.0 only return the expected capabilities", func() {
+	It("ensures that barman versions below 2.18.0 only return the expected capabilities", func() {
 		version, err := semver.ParseTolerant("2.17.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)
@@ -113,6 +135,11 @@ var _ = Describe("detect capabilities", func() {
 			HasAzure:           true,
 			HasS3:              true,
 			HasRetentionPolicy: true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+			},
 		}), "unexpected capabilities set to true")
 	})
 
@@ -124,6 +151,11 @@ var _ = Describe("detect capabilities", func() {
 			Version:  &version,
 			HasAzure: true,
 			HasS3:    true,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+			},
 		}))
 	})
 
@@ -133,6 +165,11 @@ var _ = Describe("detect capabilities", func() {
 		capabilities := detect(&version)
 		Expect(capabilities).To(Equal(&Capabilities{
 			Version: &version,
+			supportedCompressions: []barmanApi.CompressionType{
+				barmanApi.CompressionTypeNone,
+				barmanApi.CompressionTypeBzip2,
+				barmanApi.CompressionTypeGzip,
+			},
 		}))
 	})
 })

--- a/pkg/capabilities/detect_test.go
+++ b/pkg/capabilities/detect_test.go
@@ -25,6 +25,29 @@ import (
 
 var _ = Describe("detect capabilities", func() {
 	It("ensures that all capabilities are true for the 3.4 version", func() {
+		version, err := semver.ParseTolerant("3.12.0")
+		Expect(err).ToNot(HaveOccurred())
+		capabilities := detect(&version)
+		Expect(capabilities).To(Equal(&Capabilities{
+			Version:                    &version,
+			hasName:                    true,
+			HasAzure:                   true,
+			HasS3:                      true,
+			HasGoogle:                  true,
+			HasRetentionPolicy:         true,
+			HasTags:                    true,
+			HasCheckWalArchive:         true,
+			HasSnappy:                  true,
+			HasZSTD:                    true,
+			HasLZ4:                     true,
+			HasXZ:                      true,
+			HasErrorCodesForWALRestore: true,
+			HasErrorCodesForRestore:    true,
+			HasAzureManagedIdentity:    true,
+		}))
+	})
+
+	It("ensures that all capabilities are true for the 3.4 version", func() {
 		version, err := semver.ParseTolerant("3.4.0")
 		Expect(err).ToNot(HaveOccurred())
 		capabilities := detect(&version)

--- a/pkg/capabilities/type.go
+++ b/pkg/capabilities/type.go
@@ -33,6 +33,9 @@ type Capabilities struct {
 	HasTags                    bool
 	HasCheckWalArchive         bool
 	HasSnappy                  bool
+	HasZSTD                    bool
+	HasLZ4                     bool
+	HasXZ                      bool
 	HasErrorCodesForWALRestore bool
 	HasErrorCodesForRestore    bool
 	HasAzureManagedIdentity    bool

--- a/pkg/capabilities/type.go
+++ b/pkg/capabilities/type.go
@@ -19,6 +19,8 @@ package capabilities
 
 import (
 	"github.com/blang/semver"
+
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 )
 
 // Capabilities collects a set of boolean values that shows the possible capabilities of Barman and the version
@@ -32,13 +34,10 @@ type Capabilities struct {
 	HasRetentionPolicy         bool
 	HasTags                    bool
 	HasCheckWalArchive         bool
-	HasSnappy                  bool
-	HasZSTD                    bool
-	HasLZ4                     bool
-	HasXZ                      bool
 	HasErrorCodesForWALRestore bool
 	HasErrorCodesForRestore    bool
 	HasAzureManagedIdentity    bool
+	supportedCompressions      []barmanApi.CompressionType
 }
 
 // LegacyExecutor allows this code to know
@@ -54,4 +53,19 @@ func (c *Capabilities) ShouldExecuteBackupWithName(exec LegacyExecutor) bool {
 	}
 
 	return c.hasName
+}
+
+// HasCompression returns true if the given compression is supported by Barman
+func (c *Capabilities) HasCompression(compression barmanApi.CompressionType) bool {
+	if c == nil {
+		return false
+	}
+
+	for _, item := range c.supportedCompressions {
+		if item == compression {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
This adds support for the three compression options that were added as compressors in Barman 3.12, and which should hopefully improve RTO for compressed object store backups.