### PR TITLE
fix: remove lz4, xz, and zstd compression for backups

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -274,8 +274,8 @@ type WalBackupConfiguration struct {
 type DataBackupConfiguration struct {
 	// Compress a backup file (a tar file per tablespace) while streaming it
 	// to the object store. Available options are empty string (no
-	// compression, default), `gzip`, `bzip2`, `lz4`, `snappy`, `xz`, and `zstd`.
-	// +kubebuilder:validation:Enum=bzip2;gzip;lz4;snappy;xz;zstd
+	// compression, default), `gzip`, `bzip2`, and `snappy`.
+	// +kubebuilder:validation:Enum=bzip2;gzip;snappy
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 


### PR DESCRIPTION
Closes #88 