### PR TITLE
fix: incorrect env set for azure

### DIFF
--- a/pkg/credentials/env.go
+++ b/pkg/credentials/env.go
@@ -257,7 +257,7 @@ func envSetAzureCredentials(
 		if err != nil {
 			return nil, err
 		}
-		env = append(env, fmt.Sprintf("AZURE_STORAGE_SAS_TOKEN=%s", storageSasToken))
+		env = append(env, fmt.Sprintf("AZURE_STORAGE_SAS_TOKEN='%s'", storageSasToken))
 	}
 
 	if configuration.Azure.ConnectionString != nil {
@@ -270,7 +270,7 @@ func envSetAzureCredentials(
 		if err != nil {
 			return nil, err
 		}
-		env = append(env, fmt.Sprintf("AZURE_STORAGE_CONNECTION_STRING=%s", connString))
+		env = append(env, fmt.Sprintf("AZURE_STORAGE_CONNECTION_STRING='%s'", connString))
 	}
 
 	return env, nil


### PR DESCRIPTION
sas token contains `=`, use `AZURE_STORAGE_SAS_TOKEN=xxx=xxxx` would cause some unexpected error