### PR TITLE
fix: backup.go failer

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -91,8 +91,8 @@ func (b *Command) GetBarmanCloudBackupOptions(
 	serverName string,
 ) ([]string, error) {
 	options := []string{
-		"--user", "postgres",
-		"--name", backupName,
+		"-U", "postgres",
+		"-n", backupName,
 	}
 
 	options, err := b.GetDataConfiguration(options)


### PR DESCRIPTION
barman-cloud-backup has only for user the option "-U" and for the backup name "-n" and not "--user and --name".