### PR TITLE
feat: drop archived WAL files from OS page cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cloudnative-pg/machinery v0.3.1
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
+	golang.org/x/sys v0.35.0
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -56,7 +57,6 @@ require (
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/pkg/walarchive/cmd.go
+++ b/pkg/walarchive/cmd.go
@@ -20,13 +20,16 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/execlog"
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	"github.com/cloudnative-pg/machinery/pkg/log"
+	"golang.org/x/sys/unix"
 
 	"github.com/cloudnative-pg/barman-cloud/pkg/utils"
 )
@@ -86,6 +89,12 @@ func (archiver *BarmanArchiver) Archive(
 			"exitCode", barmanCloudWalArchiveCmd.ProcessState.ExitCode(),
 		)
 		return fmt.Errorf("unexpected failure invoking %s: %w", utils.BarmanCloudWalArchive, err)
+	}
+
+	if err := archiver.fadviseNotUsed(walName); err != nil {
+		contextLogger.Error(err, "Error issuing fadvise after archiving WAL",
+			"walName", walName,
+		)
 	}
 
 	// Removes the `.check-empty-wal-archive` file inside PGDATA after the
@@ -180,6 +189,28 @@ func (archiver *BarmanArchiver) CheckWalArchiveDestination(ctx context.Context, 
 	}
 
 	contextLogger.Trace("barman-cloud-check-wal-archive command execution completed")
+
+	return nil
+}
+
+// fadviseNotUsed issues an fadvise to the OS to inform that the file is not needed anymore
+func (archiver *BarmanArchiver) fadviseNotUsed(fileName string) (err error) {
+	file, err := os.Open(filepath.Clean(fileName))
+	if err != nil {
+		return fmt.Errorf("error opening file %s for fadvise: %w", fileName, err)
+	}
+
+	defer func(file *os.File) {
+		closeErr := file.Close()
+		if closeErr != nil && err == nil {
+			err = fmt.Errorf("error closing file %s for fadvise: %w", fileName, closeErr)
+		}
+	}(file)
+
+	fd := int(file.Fd())
+	if fadviseErr := unix.Fadvise(fd, 0, 0, unix.FADV_DONTNEED); fadviseErr != nil {
+		return fmt.Errorf("error issuing fadvise on file %s: %w", fileName, fadviseErr)
+	}
 
 	return nil
 }

--- a/pkg/walarchive/cmd_test.go
+++ b/pkg/walarchive/cmd_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The CloudNativePG Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package walarchive
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BarmanArchiver fadvise", func() {
+	var archiver *BarmanArchiver
+	var tempDir string
+
+	BeforeEach(func() {
+		var err error
+		tempDir, err = os.MkdirTemp("", "walarchive-test-")
+		Expect(err).ToNot(HaveOccurred())
+
+		archiver = &BarmanArchiver{}
+	})
+
+	AfterEach(func() {
+		if tempDir != "" {
+			_ = os.RemoveAll(tempDir)
+		}
+	})
+
+	Describe("fadviseNotUsed", func() {
+		It("should succeed with a valid file", func() {
+			testFile := filepath.Join(tempDir, "test-wal-file")
+			err := os.WriteFile(testFile, []byte("test WAL content"), 0o600)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = archiver.fadviseNotUsed(testFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error when file doesn't exist", func() {
+			nonExistentFile := filepath.Join(tempDir, "non-existent-file")
+
+			err := archiver.fadviseNotUsed(nonExistentFile)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error opening file"))
+		})
+
+		It("should handle empty files", func() {
+			emptyFile := filepath.Join(tempDir, "empty-wal-file")
+			err := os.WriteFile(emptyFile, []byte{}, 0o600)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = archiver.fadviseNotUsed(emptyFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should handle files with path traversal characters", func() {
+			testFile := filepath.Join(tempDir, "test-file")
+			err := os.WriteFile(testFile, []byte("content"), 0o600)
+			Expect(err).ToNot(HaveOccurred())
+
+			// filepath.Clean should handle this safely
+			fileWithDots := filepath.Join(tempDir, "..", filepath.Base(tempDir), "test-file")
+			err = archiver.fadviseNotUsed(fileWithDots)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Drop archived WAL files from the OS page cache using `fadvise(FADV_DONTNEED)`.

## Motivation

This code runs in a separate container from PostgreSQL (which handles its own memory hints). In Kubernetes, containers typically run on large machines where memory pressure is insufficient to evict cached files naturally. Without explicitly dropping archived WALs from cache, they accumulate and waste memory that could be used for active workloads.

PostgreSQL's own processes handle cache management for their files, but our archiver sidecar needs to do the same for the files it processes.

## Changes

- Added `fadviseNotUsed()` to hint the kernel to drop the file from page cache after successful archival
- Errors are logged but don't fail the operation (fadvise is advisory)
- Moved `golang.org/x/sys` to direct dependency