### PR TITLE
feat: Add DefaultAzureCredential authentication support

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -116,18 +116,10 @@ type S3Credentials struct {
 // information. If the connection string is not specified, one (and only one)
 // of the following authentication methods must be specified:
 //
-<<<<<<< HEAD
 // - storageKey (requires storageAccount)
 // - storageSasToken (requires storageAccount)
 // - inheritFromAzureAD (inheriting credentials from the pod environment)
-=======
-// - storageKey
-// - storageSasToken
-//
-// - inheriting the credentials from the pod environment by setting inheritFromAzureAD to true
-//
-// - using the default Azure authentication flow by setting useDefaultAzureCredentials to true
->>>>>>> ea1d10e (feat: add DefaultAzureCredential authentication support)
+// - useDefaultAzureCredentials (using the default Azure authentication flow)
 type AzureCredentials struct {
 	// The connection string to be used
 	// +optional

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -334,21 +334,21 @@ func (crendentials BarmanCredentials) ArePopulated() bool {
 func (azure *AzureCredentials) ValidateAzureCredentials(path *field.Path) field.ErrorList {
 	allErrors := field.ErrorList{}
 
-	secrets := 0
+	authMethods := 0
 	if azure.InheritFromAzureAD {
-		secrets++
+		authMethods++
 	}
 	if azure.UseDefaultAzureCredentials {
-		secrets++
+		authMethods++
 	}
 	if azure.StorageKey != nil {
-		secrets++
+		authMethods++
 	}
 	if azure.StorageSasToken != nil {
-		secrets++
+		authMethods++
 	}
 
-	if secrets != 1 && azure.ConnectionString == nil {
+	if authMethods != 1 && azure.ConnectionString == nil {
 		allErrors = append(
 			allErrors,
 			field.Invalid(
@@ -358,7 +358,7 @@ func (azure *AzureCredentials) ValidateAzureCredentials(path *field.Path) field.
 					"storage key, storage SAS token, Azure AD authentication, or default Azure credentials is required"))
 	}
 
-	if (secrets != 0 || azure.StorageAccount != nil) && azure.ConnectionString != nil {
+	if (authMethods != 0 || azure.StorageAccount != nil) && azure.ConnectionString != nil {
 		allErrors = append(
 			allErrors,
 			field.Invalid(

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -116,9 +116,18 @@ type S3Credentials struct {
 // information. If the connection string is not specified, one (and only one)
 // of the following authentication methods must be specified:
 //
+<<<<<<< HEAD
 // - storageKey (requires storageAccount)
 // - storageSasToken (requires storageAccount)
 // - inheritFromAzureAD (inheriting credentials from the pod environment)
+=======
+// - storageKey
+// - storageSasToken
+//
+// - inheriting the credentials from the pod environment by setting inheritFromAzureAD to true
+//
+// - using the default Azure authentication flow by setting useDefaultAzureCredentials to true
+>>>>>>> ea1d10e (feat: add DefaultAzureCredential authentication support)
 type AzureCredentials struct {
 	// The connection string to be used
 	// +optional
@@ -141,6 +150,11 @@ type AzureCredentials struct {
 	// Use the Azure AD based authentication without providing explicitly the keys.
 	// +optional
 	InheritFromAzureAD bool `json:"inheritFromAzureAD,omitempty"`
+
+	// Use the default Azure authentication flow, which includes DefaultAzureCredential.
+	// This allows authentication using environment variables and managed identities.
+	// +optional
+	UseDefaultAzureCredentials bool `json:"useDefaultAzureCredentials,omitempty"`
 }
 
 // GoogleCredentials is the type for the Google Cloud Storage credentials.
@@ -332,6 +346,9 @@ func (azure *AzureCredentials) ValidateAzureCredentials(path *field.Path) field.
 	if azure.InheritFromAzureAD {
 		secrets++
 	}
+	if azure.UseDefaultAzureCredentials {
+		secrets++
+	}
 	if azure.StorageKey != nil {
 		secrets++
 	}
@@ -346,7 +363,7 @@ func (azure *AzureCredentials) ValidateAzureCredentials(path *field.Path) field.
 				path,
 				azure,
 				"when connection string is not specified, one and only one of "+
-					"storage key, storage SAS token, or Azure AD authentication is required"))
+					"storage key, storage SAS token, Azure AD authentication, or default Azure credentials is required"))
 	}
 
 	if (secrets != 0 || azure.StorageAccount != nil) && azure.ConnectionString != nil {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -295,4 +295,45 @@ var _ = Describe("azure credentials", func() {
 		}
 		Expect(azureCredentials.ValidateAzureCredentials(path)).ToNot(BeEmpty())
 	})
+
+	It("is correct when using default azure credentials", func() {
+		azureCredentials := AzureCredentials{
+			UseDefaultAzureCredentials: true,
+		}
+		Expect(azureCredentials.ValidateAzureCredentials(path)).To(BeEmpty())
+	})
+
+	It("is not correct when multiple credential types are specified including default", func() {
+		azureCredentials := AzureCredentials{
+			UseDefaultAzureCredentials: true,
+			InheritFromAzureAD:         true,
+		}
+		Expect(azureCredentials.ValidateAzureCredentials(path)).ToNot(BeEmpty())
+	})
+
+	It("is not correct when default credentials and storage key are specified", func() {
+		azureCredentials := AzureCredentials{
+			UseDefaultAzureCredentials: true,
+			StorageKey: &machineryapi.SecretKeySelector{
+				LocalObjectReference: machineryapi.LocalObjectReference{
+					Name: "azure-config",
+				},
+				Key: "storageKey",
+			},
+		}
+		Expect(azureCredentials.ValidateAzureCredentials(path)).ToNot(BeEmpty())
+	})
+
+	It("is not correct when default credentials and connection string are specified", func() {
+		azureCredentials := AzureCredentials{
+			UseDefaultAzureCredentials: true,
+			ConnectionString: &machineryapi.SecretKeySelector{
+				LocalObjectReference: machineryapi.LocalObjectReference{
+					Name: "azure-config",
+				},
+				Key: "connectionString",
+			},
+		}
+		Expect(azureCredentials.ValidateAzureCredentials(path)).ToNot(BeEmpty())
+	})
 })

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -90,6 +90,7 @@ func appendCloudProviderOptions(
 			"--cloud-provider",
 			"azure-blob-storage")
 
+		// deprecated, to be removed in future versions
 		if useDefaultAzureCredentials(ctx) {
 			options = append(
 				options,
@@ -142,6 +143,7 @@ func useDefaultAzureCredentials(ctx context.Context) bool {
 
 // ContextWithDefaultAzureCredentials create a context that contains the contextKeyUseDefaultAzureCredentials flag.
 // When set to true barman-cloud will use the default Azure credentials.
+// Deprecated: use the api azureCredentials.UseDefaultAzureCredentials
 func ContextWithDefaultAzureCredentials(ctx context.Context, enabled bool) context.Context {
 	return context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, enabled)
 }

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -141,9 +141,10 @@ func useDefaultAzureCredentials(ctx context.Context) bool {
 	return result
 }
 
-// ContextWithDefaultAzureCredentials create a context that contains the contextKeyUseDefaultAzureCredentials flag.
+// ContextWithDefaultAzureCredentials creates a context that contains the contextKeyUseDefaultAzureCredentials flag.
 // When set to true barman-cloud will use the default Azure credentials.
-// Deprecated: use the api azureCredentials.UseDefaultAzureCredentials
+//
+// Deprecated: Use AzureCredentials.UseDefaultAzureCredentials instead.
 func ContextWithDefaultAzureCredentials(ctx context.Context, enabled bool) context.Context {
 	return context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, enabled)
 }

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -91,17 +91,28 @@ func appendCloudProviderOptions(
 			"azure-blob-storage")
 
 		if useDefaultAzureCredentials(ctx) {
+			options = append(
+				options,
+				"--credential",
+				"default")
 			break
 		}
 
-		if !credentials.Azure.InheritFromAzureAD {
+		if credentials.Azure.UseDefaultAzureCredentials {
+			options = append(
+				options,
+				"--credential",
+				"default")
 			break
 		}
 
-		options = append(
-			options,
-			"--credential",
-			"managed-identity")
+		if credentials.Azure.InheritFromAzureAD {
+			options = append(
+				options,
+				"--credential",
+				"managed-identity")
+			break
+		}
 	case credentials.Google != nil:
 		options = append(
 			options,

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"strings"
 
-	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
+
+	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	barmanApi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+	machineryapi "github.com/cloudnative-pg/machinery/pkg/api"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -77,5 +78,93 @@ var _ = Describe("useDefaultAzureCredentials", func() {
 	It("should be true only if ctx contains true value", func(ctx SpecContext) {
 		newCtx := context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, true)
 		Expect(useDefaultAzureCredentials(newCtx)).To(BeTrue())
+	})
+})
+
+var _ = Describe("AppendCloudProviderOptions with Azure credentials", func() {
+	var options []string
+
+	BeforeEach(func() {
+		options = []string{}
+	})
+
+	It("should use default credential when UseDefaultAzureCredentials is set", func(ctx SpecContext) {
+		credentials := barmanApi.BarmanCredentials{
+			Azure: &barmanApi.AzureCredentials{
+				UseDefaultAzureCredentials: true,
+			},
+		}
+		result, err := appendCloudProviderOptions(ctx, options, credentials)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(ContainElements(
+			"--cloud-provider", "azure-blob-storage",
+			"--credential", "default",
+		))
+	})
+
+	It("should use managed-identity credential when InheritFromAzureAD is set", func(ctx SpecContext) {
+		credentials := barmanApi.BarmanCredentials{
+			Azure: &barmanApi.AzureCredentials{
+				InheritFromAzureAD: true,
+			},
+		}
+		result, err := appendCloudProviderOptions(ctx, options, credentials)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(ContainElements(
+			"--cloud-provider", "azure-blob-storage",
+			"--credential", "managed-identity",
+		))
+	})
+
+	It("should not use any credential flag for explicit credentials", func(ctx SpecContext) {
+		credentials := barmanApi.BarmanCredentials{
+			Azure: &barmanApi.AzureCredentials{
+				StorageAccount: &machineryapi.SecretKeySelector{
+					LocalObjectReference: machineryapi.LocalObjectReference{
+						Name: "test",
+					},
+					Key: "account",
+				},
+				StorageKey: &machineryapi.SecretKeySelector{
+					LocalObjectReference: machineryapi.LocalObjectReference{
+						Name: "test",
+					},
+					Key: "key",
+				},
+			},
+		}
+		result, err := appendCloudProviderOptions(ctx, options, credentials)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal([]string{
+			"--cloud-provider", "azure-blob-storage",
+		}))
+	})
+
+	It("should use default credential from context when context flag is set", func(ctx SpecContext) {
+		credentials := barmanApi.BarmanCredentials{
+			Azure: &barmanApi.AzureCredentials{},
+		}
+		newCtx := context.WithValue(ctx, contextKeyUseDefaultAzureCredentials, true)
+		result, err := appendCloudProviderOptions(newCtx, options, credentials)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(ContainElements(
+			"--cloud-provider", "azure-blob-storage",
+			"--credential", "default",
+		))
+	})
+
+	It("should prioritize UseDefaultAzureCredentials over InheritFromAzureAD", func(ctx SpecContext) {
+		credentials := barmanApi.BarmanCredentials{
+			Azure: &barmanApi.AzureCredentials{
+				UseDefaultAzureCredentials: true,
+				InheritFromAzureAD:         true,
+			},
+		}
+		result, err := appendCloudProviderOptions(ctx, options, credentials)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(ContainElements(
+			"--cloud-provider", "azure-blob-storage",
+			"--credential", "default",
+		))
 	})
 })

--- a/pkg/credentials/env.go
+++ b/pkg/credentials/env.go
@@ -218,6 +218,10 @@ func envSetAzureCredentials(
 		return env, nil
 	}
 
+	if configuration.Azure.UseDefaultAzureCredentials {
+		return env, nil
+	}
+
 	// Get storage account name
 	if configuration.Azure.StorageAccount != nil {
 		storageAccount, err := extractValueFromSecret(


### PR DESCRIPTION
Support the Azure SDK DefaultAzureCredential authentication flow, which allows
credential authentication through environment variables (AZURE_CLIENT_ID,
AZURE_TENANT_ID, AZURE_CLIENT_SECRET) and managed identities in AKS environments.

