### PR TITLE
fix: misleading message about Azure if no ObjectStore credentials defined

### DIFF
--- a/pkg/credentials/env.go
+++ b/pkg/credentials/env.go
@@ -118,7 +118,11 @@ func envSetCloudCredentials(
 		return envSetGoogleCredentials(ctx, c, namespace, configuration.Google, env)
 	}
 
-	return envSetAzureCredentials(ctx, c, namespace, configuration, env)
+	if configuration.Azure != nil {
+		return envSetAzureCredentials(ctx, c, namespace, configuration, env)
+	}
+
+	return nil, fmt.Errorf("ObjectStoreConfiguration invalid: no credentials defined")
 }
 
 // envSetAWSCredentials sets the AWS environment variables given the configuration


### PR DESCRIPTION
If azureCredentials, googleCredentials and s3Credentials are nil, the resulting error message says "missing Azure credentials", which is misleading.

Add a specific error message for this case.