### PR TITLE
feat: add --timeline support to BarmanCloudCheckWalArchiveOptions

### DIFF
--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -20,6 +20,7 @@ package archiver
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/cloudnative-pg/machinery/pkg/log"
@@ -131,13 +132,45 @@ func (archiver *WALArchiver) CheckWalArchiveDestination(ctx context.Context, opt
 	return archiver.barmanArchiver.CheckWalArchiveDestination(ctx, options)
 }
 
-// BarmanCloudCheckWalArchiveOptions create the options needed for the `barman-cloud-check-wal-archive`
-// command.
+// CheckWalArchiveOpts holds optional parameters for
+// BarmanCloudCheckWalArchiveOptions.
+type CheckWalArchiveOpts struct {
+	// Timeline, when > 0, is passed as --timeline to
+	// barman-cloud-check-wal-archive so that WAL segments from earlier
+	// timelines (expected after a failover/promotion) do not trigger the
+	// "Expected empty archive" safety check.
+	Timeline int
+}
+
+// CheckWalArchiveOption is a functional option for
+// BarmanCloudCheckWalArchiveOptions.
+type CheckWalArchiveOption func(*CheckWalArchiveOpts)
+
+// WithTimeline returns a CheckWalArchiveOption that passes --timeline to
+// barman-cloud-check-wal-archive. The value should be the server's current
+// PostgreSQL timeline, so that WAL from earlier timelines in the archive
+// is treated as expected (e.g. after a failover) rather than as an error.
+func WithTimeline(tl int) CheckWalArchiveOption {
+	return func(o *CheckWalArchiveOpts) { o.Timeline = tl }
+}
+
+// BarmanCloudCheckWalArchiveOptions creates the options needed for the
+// `barman-cloud-check-wal-archive` command.
+//
+// Callers may pass functional options such as WithTimeline to customise
+// the command arguments. Existing callers that pass no options continue
+// to work unchanged.
 func (archiver *WALArchiver) BarmanCloudCheckWalArchiveOptions(
 	ctx context.Context,
 	configuration *api.BarmanObjectStoreConfiguration,
 	clusterName string,
+	opts ...CheckWalArchiveOption,
 ) ([]string, error) {
+	var cfg CheckWalArchiveOpts
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	var options []string
 	if len(configuration.EndpointURL) > 0 {
 		options = append(
@@ -149,6 +182,10 @@ func (archiver *WALArchiver) BarmanCloudCheckWalArchiveOptions(
 	options, err := command.AppendCloudProviderOptionsFromConfiguration(ctx, options, configuration)
 	if err != nil {
 		return nil, err
+	}
+
+	if cfg.Timeline > 0 {
+		options = append(options, "--timeline", strconv.Itoa(cfg.Timeline))
 	}
 
 	serverName := clusterName

--- a/pkg/archiver/command_test.go
+++ b/pkg/archiver/command_test.go
@@ -26,6 +26,73 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("barmanCloudCheckWalArchiveOptions", func() {
+	var config *barmanApi.BarmanObjectStoreConfiguration
+	var tempDir string
+	var tempEmptyWalArchivePath string
+
+	BeforeEach(func() {
+		config = &barmanApi.BarmanObjectStoreConfiguration{
+			DestinationPath: "s3://bucket-name/",
+			EndpointURL:     "https://s3.example.com",
+		}
+		var err error
+		tempDir, err = os.MkdirTemp(os.TempDir(), "check_command_test")
+		Expect(err).ToNot(HaveOccurred())
+		file, err := os.CreateTemp(tempDir, "empty-wal-archive-path")
+		Expect(err).ToNot(HaveOccurred())
+		tempEmptyWalArchivePath = file.Name()
+	})
+	AfterEach(func() {
+		err := os.RemoveAll(tempDir)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should generate correct arguments without timeline", func(ctx SpecContext) {
+		archiver, err := New(ctx, nil, "spool", "pgdata", tempEmptyWalArchivePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		options, err := archiver.BarmanCloudCheckWalArchiveOptions(ctx, config, "test-cluster")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(Equal("--endpoint-url https://s3.example.com s3://bucket-name/ test-cluster"))
+	})
+
+	It("should include --timeline when WithTimeline is passed", func(ctx SpecContext) {
+		archiver, err := New(ctx, nil, "spool", "pgdata", tempEmptyWalArchivePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		options, err := archiver.BarmanCloudCheckWalArchiveOptions(
+			ctx, config, "test-cluster", WithTimeline(2))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(Equal("--endpoint-url https://s3.example.com --timeline 2 s3://bucket-name/ test-cluster"))
+	})
+
+	It("should not include --timeline when timeline is zero", func(ctx SpecContext) {
+		archiver, err := New(ctx, nil, "spool", "pgdata", tempEmptyWalArchivePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		options, err := archiver.BarmanCloudCheckWalArchiveOptions(
+			ctx, config, "test-cluster", WithTimeline(0))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(Equal("--endpoint-url https://s3.example.com s3://bucket-name/ test-cluster"))
+	})
+
+	It("should use serverName when configured", func(ctx SpecContext) {
+		archiver, err := New(ctx, nil, "spool", "pgdata", tempEmptyWalArchivePath)
+		Expect(err).ToNot(HaveOccurred())
+
+		config.ServerName = "custom-server"
+		options, err := archiver.BarmanCloudCheckWalArchiveOptions(
+			ctx, config, "test-cluster", WithTimeline(3))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Join(options, " ")).
+			To(Equal("--endpoint-url https://s3.example.com --timeline 3 s3://bucket-name/ custom-server"))
+	})
+})
+
 var _ = Describe("barmanCloudWalArchiveOptions", func() {
 	var config *barmanApi.BarmanObjectStoreConfiguration
 	var tempDir string


### PR DESCRIPTION
## Summary

- Add a variadic functional option pattern (`WithTimeline`) to `BarmanCloudCheckWalArchiveOptions` that passes `--timeline` to `barman-cloud-check-wal-archive`
- This allows the empty-archive safety check to tolerate WAL from earlier timelines, which is the expected state after a failover/promotion
- The API change is backwards-compatible: existing callers that pass no options compile and behave identically

## Context

After a failover, WAL archiving permanently breaks because `barman-cloud-check-wal-archive` rejects the archive with "Expected empty archive" — it finds WAL from the previous timeline and has no way to know that's expected. The upstream barman tool already supports `--timeline` for exactly this case, but the Go wrapper never passes it.

This PR adds the plumbing in `barman-cloud`. The companion PR in `plugin-barman-cloud` ([cloudnative-pg/plugin-barman-cloud#842](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/842)) will detect the current timeline from `pg_controldata` and pass it via `WithTimeline`.

## Test plan

- [x] New Ginkgo tests for `BarmanCloudCheckWalArchiveOptions`: without timeline, with timeline, with zero timeline, with custom serverName + timeline
- [x] Existing tests pass unchanged (zero-opts callers are unaffected)

Ref: cloudnative-pg/plugin-barman-cloud#842

Assisted-by: Claude Opus 4.6
Assisted-by: GPT-5.4 in Cursor