### PR TITLE
fix: allow lz4 compression for base backups

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -279,8 +279,8 @@ type WalBackupConfiguration struct {
 type DataBackupConfiguration struct {
 	// Compress a backup file (a tar file per tablespace) while streaming it
 	// to the object store. Available options are empty string (no
-	// compression, default), `gzip`, `bzip2`, and `snappy`.
-	// +kubebuilder:validation:Enum=bzip2;gzip;snappy
+	// compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
+	// +kubebuilder:validation:Enum=bzip2;gzip;lz4;snappy
 	// +optional
 	Compression CompressionType `json:"compression,omitempty"`
 


### PR DESCRIPTION
Barman 3.18.0 added `--lz4` to `barman-cloud-backup` (EnterpriseDB/barman@468641b). Put `lz4` back in the `DataBackupConfiguration` enum; it was removed in #89 when no base-backup tool accepted it.

Closes #215