### PR TITLE
feat(restorer): add sentinel errors for WAL restore failures

### DIFF
--- a/pkg/restorer/restorer.go
+++ b/pkg/restorer/restorer.go
@@ -46,8 +46,8 @@ var ErrWALNotFound = errors.New("WAL not found")
 // connectivity issue with the object storage
 var ErrConnectivity = errors.New("connectivity failure")
 
-// ErrInvalidWalName is returned when the WAL name is not valid
-var ErrInvalidWalName = errors.New("invalid WAL name")
+// ErrInvalidWALName is returned when the WAL name is not valid
+var ErrInvalidWALName = errors.New("invalid WAL name")
 
 // ErrGeneric is returned when barman-cloud-wal-restore fails with a generic
 // error
@@ -298,7 +298,7 @@ func (restorer *WALRestorer) Restore(
 		return fmt.Errorf("connectivity failure while executing %s, retrying: %w",
 			utils.BarmanCloudWalRestore, ErrConnectivity)
 	case exitCodeInvalidWalName:
-		return fmt.Errorf("invalid name for a WAL file %q: %w", walName, ErrInvalidWalName)
+		return fmt.Errorf("invalid name for a WAL file %q: %w", walName, ErrInvalidWALName)
 	case exitCodeGeneric:
 		return fmt.Errorf("generic error code encountered while executing %s: %w",
 			utils.BarmanCloudWalRestore, ErrGeneric)

--- a/pkg/restorer/restorer.go
+++ b/pkg/restorer/restorer.go
@@ -42,6 +42,21 @@ const (
 // ErrWALNotFound is returned when the WAL is not found in the cloud archive
 var ErrWALNotFound = errors.New("WAL not found")
 
+// ErrConnectivity is returned when barman-cloud-wal-restore fails due to a
+// connectivity issue with the object storage
+var ErrConnectivity = errors.New("connectivity failure")
+
+// ErrInvalidWalName is returned when the WAL name is not valid
+var ErrInvalidWalName = errors.New("invalid WAL name")
+
+// ErrGeneric is returned when barman-cloud-wal-restore fails with a generic
+// error
+var ErrGeneric = errors.New("generic error")
+
+// ErrUnrecognizedExitCode is returned when barman-cloud-wal-restore exits with
+// an unrecognized exit code
+var ErrUnrecognizedExitCode = errors.New("unrecognized exit code")
+
 // WALRestorer is a structure containing every info needed to restore
 // some WALs from the object storage
 type WALRestorer struct {
@@ -280,16 +295,17 @@ func (restorer *WALRestorer) Restore(
 	case exitCodeBucketOrWalNotFound:
 		return fmt.Errorf("object storage or file not found %s: %w", walName, ErrWALNotFound)
 	case exitCodeConnectivityError:
-		return fmt.Errorf("connectivity failure while executing %s, retrying",
-			utils.BarmanCloudWalRestore)
+		return fmt.Errorf("connectivity failure while executing %s, retrying: %w",
+			utils.BarmanCloudWalRestore, ErrConnectivity)
 	case exitCodeInvalidWalName:
-		return fmt.Errorf("invalid name for a WAL file: %s", walName)
+		return fmt.Errorf("invalid name for a WAL file %q: %w", walName, ErrInvalidWalName)
 	case exitCodeGeneric:
-		return fmt.Errorf("generic error code encountered while executing %s",
-			utils.BarmanCloudWalRestore)
+		return fmt.Errorf("generic error code encountered while executing %s: %w",
+			utils.BarmanCloudWalRestore, ErrGeneric)
 	default:
-		return fmt.Errorf("encountered an unrecognized exit code error: '%d' while executing %s",
+		return fmt.Errorf("encountered an unrecognized exit code error: '%d' while executing %s: %w",
 			exitCode,
-			utils.BarmanCloudWalRestore)
+			utils.BarmanCloudWalRestore,
+			ErrUnrecognizedExitCode)
 	}
 }

--- a/pkg/restorer/restorer.go
+++ b/pkg/restorer/restorer.go
@@ -252,11 +252,13 @@ func (restorer *WALRestorer) RestoreList(
 	return resultList
 }
 
-// Restore restores a WAL file from the object store
-func (restorer *WALRestorer) Restore(
-	walName, destinationPath string,
-	baseOptions []string,
-) error {
+// errorForExitCode maps a barman-cloud-wal-restore exit code to the
+// corresponding wrapped sentinel error so callers can identify the
+// failure class via errors.Is.
+func errorForExitCode(exitCode int, walName string) error {
+	// barman-cloud-wal-restore exit codes.
+	// nolint: lll
+	// source: https://github.com/EnterpriseDB/barman/blob/26ed480cd0268dfd3f8546cc97660d4bd827772a/tests/test_barman_cloud_wal_restore.py
 	const (
 		exitCodeBucketOrWalNotFound = 1
 		exitCodeConnectivityError   = 2
@@ -264,6 +266,30 @@ func (restorer *WALRestorer) Restore(
 		exitCodeGeneric             = 4
 	)
 
+	switch exitCode {
+	case exitCodeBucketOrWalNotFound:
+		return fmt.Errorf("object storage or file not found %s: %w", walName, ErrWALNotFound)
+	case exitCodeConnectivityError:
+		return fmt.Errorf("connectivity failure while executing %s, retrying: %w",
+			utils.BarmanCloudWalRestore, ErrConnectivity)
+	case exitCodeInvalidWalName:
+		return fmt.Errorf("invalid name for a WAL file %q: %w", walName, ErrInvalidWALName)
+	case exitCodeGeneric:
+		return fmt.Errorf("generic error code encountered while executing %s: %w",
+			utils.BarmanCloudWalRestore, ErrGeneric)
+	default:
+		return fmt.Errorf("encountered an unrecognized exit code error: '%d' while executing %s: %w",
+			exitCode,
+			utils.BarmanCloudWalRestore,
+			ErrUnrecognizedExitCode)
+	}
+}
+
+// Restore restores a WAL file from the object store
+func (restorer *WALRestorer) Restore(
+	walName, destinationPath string,
+	baseOptions []string,
+) error {
 	optionsLength := len(baseOptions)
 	if optionsLength >= math.MaxInt-2 {
 		return fmt.Errorf("can't restore wal file %v, options too long", walName)
@@ -288,24 +314,5 @@ func (restorer *WALRestorer) Restore(
 			walName, utils.BarmanCloudWalRestore, err)
 	}
 
-	// nolint: lll
-	// source: https://github.com/EnterpriseDB/barman/blob/26ed480cd0268dfd3f8546cc97660d4bd827772a/tests/test_barman_cloud_wal_restore.py
-	exitCode := exitError.ExitCode()
-	switch exitCode {
-	case exitCodeBucketOrWalNotFound:
-		return fmt.Errorf("object storage or file not found %s: %w", walName, ErrWALNotFound)
-	case exitCodeConnectivityError:
-		return fmt.Errorf("connectivity failure while executing %s, retrying: %w",
-			utils.BarmanCloudWalRestore, ErrConnectivity)
-	case exitCodeInvalidWalName:
-		return fmt.Errorf("invalid name for a WAL file %q: %w", walName, ErrInvalidWALName)
-	case exitCodeGeneric:
-		return fmt.Errorf("generic error code encountered while executing %s: %w",
-			utils.BarmanCloudWalRestore, ErrGeneric)
-	default:
-		return fmt.Errorf("encountered an unrecognized exit code error: '%d' while executing %s: %w",
-			exitCode,
-			utils.BarmanCloudWalRestore,
-			ErrUnrecognizedExitCode)
-	}
+	return errorForExitCode(exitError.ExitCode(), walName)
 }

--- a/pkg/restorer/restorer_test.go
+++ b/pkg/restorer/restorer_test.go
@@ -21,6 +21,7 @@ package restorer
 
 import (
 	"errors"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,7 +59,7 @@ var _ = Describe("errorForExitCode", func() {
 		// error with additional context. errors.Is must still resolve the
 		// original sentinel through any number of wraps.
 		base := errorForExitCode(2, walName)
-		outer := errors.Join(errors.New("outer context"), base)
+		outer := fmt.Errorf("outer context: %w", base)
 		Expect(errors.Is(outer, ErrConnectivity)).To(BeTrue())
 	})
 })

--- a/pkg/restorer/restorer_test.go
+++ b/pkg/restorer/restorer_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restorer
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("errorForExitCode", func() {
+	const walName = "000000010000000000000001"
+
+	DescribeTable(
+		"wraps the expected sentinel and remains identifiable via errors.Is",
+		func(exitCode int, expectedSentinel error) {
+			err := errorForExitCode(exitCode, walName)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, expectedSentinel)).
+				To(BeTrue(), "expected errors.Is to find %v in %q", expectedSentinel, err)
+		},
+		// Exit codes match the barman documentation referenced in
+		// errorForExitCode; the per-Entry text labels each one.
+		Entry("exit 1 -> ErrWALNotFound", 1, ErrWALNotFound),
+		Entry("exit 2 -> ErrConnectivity", 2, ErrConnectivity),
+		Entry("exit 3 -> ErrInvalidWALName", 3, ErrInvalidWALName),
+		Entry("exit 4 -> ErrGeneric", 4, ErrGeneric),
+		Entry("unrecognized exit code -> ErrUnrecognizedExitCode", 99, ErrUnrecognizedExitCode),
+	)
+
+	It("includes the WAL name in the messages that mention it", func() {
+		// The two branches that interpolate walName must keep doing so;
+		// the others reference the command name instead.
+		Expect(errorForExitCode(1, walName).Error()).To(ContainSubstring(walName))
+		Expect(errorForExitCode(3, walName).Error()).To(ContainSubstring(walName))
+	})
+
+	It("survives further wrapping via fmt.Errorf %w", func() {
+		// Downstream callers (operator, plugins) often wrap the restorer's
+		// error with additional context. errors.Is must still resolve the
+		// original sentinel through any number of wraps.
+		base := errorForExitCode(2, walName)
+		outer := errors.Join(errors.New("outer context"), base)
+		Expect(errors.Is(outer, ErrConnectivity)).To(BeTrue())
+	})
+})

--- a/pkg/restorer/suite_test.go
+++ b/pkg/restorer/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package restorer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestorer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Restorer test suite")
+}


### PR DESCRIPTION
Expose ErrConnectivity, ErrInvalidWalName, ErrGeneric, and ErrUnrecognizedExitCode alongside the existing ErrWALNotFound, and wrap them in the corresponding exit-code branches of Restore. This lets callers distinguish failure modes via errors.Is instead of matching on error strings.