### PR TITLE
feat(api): add S3 addressing style configuration

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -165,6 +165,18 @@ type GoogleCredentials struct {
 	GKEEnvironment bool `json:"gkeEnvironment,omitempty"`
 }
 
+// S3AddressingStyle controls how bucket names are included in S3 requests.
+type S3AddressingStyle string
+
+const (
+	// S3AddressingStyleAuto lets the S3 client select the addressing style.
+	S3AddressingStyleAuto S3AddressingStyle = "auto"
+	// S3AddressingStyleVirtual uses virtual-hosted-style S3 requests.
+	S3AddressingStyleVirtual S3AddressingStyle = "virtual"
+	// S3AddressingStylePath uses path-style S3 requests.
+	S3AddressingStylePath S3AddressingStyle = "path"
+)
+
 // BarmanObjectStoreConfiguration contains the backup configuration
 // using Barman against an S3-compatible object storage
 type BarmanObjectStoreConfiguration struct {
@@ -175,6 +187,12 @@ type BarmanObjectStoreConfiguration struct {
 	// overriding the automatic endpoint discovery
 	// +optional
 	EndpointURL string `json:"endpointURL,omitempty"`
+
+	// The addressing style to use for S3 requests.
+	// When not specified, the S3 client selects the addressing style automatically.
+	// +kubebuilder:validation:Enum=auto;virtual;path
+	// +optional
+	AddressingStyle S3AddressingStyle `json:"addressingStyle,omitempty"`
 
 	// EndpointCA store the CA bundle of the barman endpoint.
 	// Useful when using self-signed certificates to avoid

--- a/pkg/command/commandbuilder.go
+++ b/pkg/command/commandbuilder.go
@@ -62,7 +62,16 @@ func AppendCloudProviderOptionsFromConfiguration(
 	options []string,
 	barmanConfiguration *barmanApi.BarmanObjectStoreConfiguration,
 ) ([]string, error) {
-	return appendCloudProviderOptions(ctx, options, barmanConfiguration.BarmanCredentials)
+	options, err := appendCloudProviderOptions(ctx, options, barmanConfiguration.BarmanCredentials)
+	if err != nil {
+		return nil, err
+	}
+
+	if barmanConfiguration.AWS != nil && barmanConfiguration.AddressingStyle != "" {
+		options = append(options, "--addressing-style", string(barmanConfiguration.AddressingStyle))
+	}
+
+	return options, nil
 }
 
 // AppendCloudProviderOptionsFromBackup takes an options array and adds the cloud provider specified

--- a/pkg/command/commandbuilder_test.go
+++ b/pkg/command/commandbuilder_test.go
@@ -172,3 +172,46 @@ var _ = Describe("AppendCloudProviderOptions with Azure credentials", func() {
 		))
 	})
 })
+
+var _ = Describe("AppendCloudProviderOptionsFromConfiguration with S3 addressing style", func() {
+	It("should append the addressing style for AWS S3", func(ctx SpecContext) {
+		configuration := &barmanApi.BarmanObjectStoreConfiguration{
+			BarmanCredentials: barmanApi.BarmanCredentials{
+				AWS: &barmanApi.S3Credentials{},
+			},
+			AddressingStyle: barmanApi.S3AddressingStyleVirtual,
+		}
+
+		result, err := AppendCloudProviderOptionsFromConfiguration(ctx, nil, configuration)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal([]string{
+			"--cloud-provider", "aws-s3",
+			"--addressing-style", "virtual",
+		}))
+	})
+
+	It("should omit the addressing style when it is not configured", func(ctx SpecContext) {
+		configuration := &barmanApi.BarmanObjectStoreConfiguration{
+			BarmanCredentials: barmanApi.BarmanCredentials{
+				AWS: &barmanApi.S3Credentials{},
+			},
+		}
+
+		result, err := AppendCloudProviderOptionsFromConfiguration(ctx, nil, configuration)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal([]string{"--cloud-provider", "aws-s3"}))
+	})
+
+	It("should ignore the addressing style for non-S3 providers", func(ctx SpecContext) {
+		configuration := &barmanApi.BarmanObjectStoreConfiguration{
+			BarmanCredentials: barmanApi.BarmanCredentials{
+				Google: &barmanApi.GoogleCredentials{},
+			},
+			AddressingStyle: barmanApi.S3AddressingStyleVirtual,
+		}
+
+		result, err := AppendCloudProviderOptionsFromConfiguration(ctx, nil, configuration)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal([]string{"--cloud-provider", "google-cloud-storage"}))
+	})
+})


### PR DESCRIPTION
Some S3-compatible object stores require virtual-hosted-style requests and reject path-style requests.

Barman supports configuring `--addressing-style`: https://github.com/EnterpriseDB/barman/commit/e81a459d187d7495760e900605326999b146e610

`barman-cloud` supports passing this configuration in a round-about way via various `additionalCommandArgs`: https://github.com/cloudnative-pg/barman-cloud/blob/950b0f57e122e9bbfef059193801a34664cfd3ad/pkg/archiver/command.go#L51

However that requires configuring the same command argument at every command builder that calls `barman` - additionally, the current interface does not support passing additional args to `barman-cloud-backup-list`, `barman-cloud-backup-show`, `barman-cloud-backup-delete`.

Rather than requiring virtual host consumers to duplicate the argument surface - add a top-level `addressingStyle` configuration that appends to command builder, so the single configuration parameter passes down to all calling instances of `barman`.