### PR TITLE
fix(credentials): honour the S3 region when inheriting an IAM role

### DIFF
--- a/pkg/credentials/env.go
+++ b/pkg/credentials/env.go
@@ -142,6 +142,26 @@ func envSetAWSCredentials(
 		return nil, fmt.Errorf("missing S3 credentials")
 	}
 
+	// Get the region, before the role-based exit below rather than alongside the
+	// keys. The region is not a credential: it can say where a bucket is, and a
+	// store in another region needs it whichever way the pod authenticates. Read
+	// after the exit, a store reached through an IAM role could never be told its
+	// region, so it fell back to whatever the pod environment happened to say.
+	// For a bucket outside that region is the wrong answer, and not one the
+	// configuration had any way to correct.
+	if s3credentials.RegionReference != nil {
+		region, regionErr := extractValueFromSecret(
+			ctx,
+			client,
+			s3credentials.RegionReference,
+			namespace,
+		)
+		if regionErr != nil {
+			return nil, regionErr
+		}
+		env = append(env, fmt.Sprintf("AWS_DEFAULT_REGION=%s", region))
+	}
+
 	if s3credentials.InheritFromIAMRole {
 		return env, nil
 	}
@@ -172,19 +192,6 @@ func envSetAWSCredentials(
 	)
 	if secretAccessErr != nil {
 		return nil, secretAccessErr
-	}
-
-	if s3credentials.RegionReference != nil {
-		region, regionErr := extractValueFromSecret(
-			ctx,
-			client,
-			s3credentials.RegionReference,
-			namespace,
-		)
-		if regionErr != nil {
-			return nil, regionErr
-		}
-		env = append(env, fmt.Sprintf("AWS_DEFAULT_REGION=%s", region))
 	}
 
 	// Get session token secret


### PR DESCRIPTION
Move the `envSetAWSCredentials` read of `RegionReference` before the early return for `InheritFromIAMRole`, so a store configured with a region receives one when the pod authenticates through its role. The `barman` process otherwise fell back to whatever `AWS_DEFAULT_REGION` the pod environment happened to carry, which for a bucket outside that region is the wrong answer and not one the `ObjectStore` had any way to correct.

This comes useful when a single pod needs access to two `ObjectStores` living in two different regions, like when doing a restore of a Postgres cluster in a different region.